### PR TITLE
Get Travis build working in Unity 5.3+

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,8 +1,8 @@
 #! /bin/sh
 
 BASE_URL=http://netstorage.unity3d.com/unity
-HASH=3757309da7e7
-VERSION=5.2.2f1
+HASH=e87ab445ead0
+VERSION=5.3.2f1
 
 download() {
   file=$1
@@ -17,8 +17,14 @@ install() {
   download "$package"
 
   echo "Installing "`basename "$package"`
-  #sudo installer -dumplog -package `basename "$package"` -target /
+  sudo installer -dumplog -package `basename "$package"` -target /
 }
 
+# See $BASE_URL/$HASH/unity-$VERSION-$PLATFORM.ini for complete list
+# of available packages, where PLATFORM is `osx` or `win`
+
 install "MacEditorInstaller/Unity-$VERSION.pkg"
+install "MacEditorTargetInstaller/UnitySetup-Windows-Support-for-Editor-$VERSION.pkg"
+install "MacEditorTargetInstaller/UnitySetup-Mac-Support-for-Editor-$VERSION.pkg"
+install "MacEditorTargetInstaller/UnitySetup-Linux-Support-for-Editor-$VERSION.pkg"
 

--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -1,7 +1,24 @@
 #! /bin/sh
 
-echo 'Downloading from http://netstorage.unity3d.com/unity/3757309da7e7/MacEditorInstaller/Unity-5.2.2f1.pkg: '
-curl -o Unity.pkg http://netstorage.unity3d.com/unity/3757309da7e7/MacEditorInstaller/Unity-5.2.2f1.pkg
+BASE_URL=http://netstorage.unity3d.com/unity
+HASH=3757309da7e7
+VERSION=5.2.2f1
 
-echo 'Installing Unity.pkg'
-sudo installer -dumplog -package Unity.pkg -target /
+download() {
+  file=$1
+  url="$BASE_URL/$HASH/$package"
+
+  echo "Downloading from $url: "
+  curl -o `basename "$package"` "$url"
+}
+
+install() {
+  package=$1
+  download "$package"
+
+  echo "Installing "`basename "$package"`
+  #sudo installer -dumplog -package `basename "$package"` -target /
+}
+
+install "MacEditorInstaller/Unity-$VERSION.pkg"
+


### PR DESCRIPTION
This fixes issue #2. The story:

I figured the Unity Download Assistant probably had some index of where it was downloading everything from. Sure enough, in `Unity Download Assistant.app/Contents/Resources/settings.ini` there was a
link to a hosted `ini` file which has the actual download information.

Example for the version I bumped to: http://netstorage.unity3d.com/unity/e87ab445ead0/unity-5.3.2f1-osx.ini

Once I got there I saw it's just the same standard naming format for the other micropackages, and I set it up from there.

Works like a dream. :)
